### PR TITLE
Using python's os.pathsep to seperate env vars

### DIFF
--- a/snmpclitools/cli/mibview.py
+++ b/snmpclitools/cli/mibview.py
@@ -358,10 +358,10 @@ class MibViewProxy(object):
             self.DEFAULT_OID_PREFIX = os.environ['PYSNMPOIDPREFIX']
 
         if 'PYSNMPMIBS' in os.environ:
-            self.DEFAULT_MIBS = os.environ['PYSNMPMIBS'].split(':')
+            self.DEFAULT_MIBS = os.environ['PYSNMPMIBS'].split(os.pathsep)
 
         if 'PYSNMPMIBDIRS' in os.environ:
-            self.DEFAULT_MIB_DIRS = os.environ['PYSNMPMIBDIRS'].split(':')
+            self.DEFAULT_MIB_DIRS = os.environ['PYSNMPMIBDIRS'].split(os.pathsep)
 
         if self.DEFAULT_MIB_DIRS:
             mibViewController.mibBuilder.setMibSources(


### PR DESCRIPTION
The os.pathsep turns into ":" on unix and ";" on windows, allowing
windows paths to contain the colon as part of their drive.

For example, using:

set PYSNMPMIBDIRS=C:\local\mibs;C:\src\mibs

Will now work on windows, on unix one can keep doing

PYSNMPMIBDIRS=/home/myuser/mibs:/srv/local/mibs

Fixes #13 