### PR TITLE
fixing Unsigned32 PDU

### DIFF
--- a/snmpclitools/cli/pdu.py
+++ b/snmpclitools/cli/pdu.py
@@ -229,7 +229,7 @@ class WritePduParserMixIn(ReadPduParserMixIn):
 class _WritePduGenerator(_ReadPduGenerator):
     TYPE_MAP = {
         'i': rfc1902.Integer(),
-        'u': rfc1902.Integer32(),
+        'u': rfc1902.Unsigned32(),
         's': rfc1902.OctetString(),
         'n': univ.Null(),
         'o': univ.ObjectIdentifier(),


### PR DESCRIPTION
Doing an SNMP_SET with the 'u' flag send a PDU for Int32. Fixed it so the PDU type is Unsigned32.

Fixes #18 